### PR TITLE
Added publishable Dockerfiles for C++, Node, Python, and Ruby

### DIFF
--- a/cxx/Dockerfile
+++ b/cxx/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM debian:latest
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  curl \
+  gcc \
+  git \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libgflags-dev \
+  libtool \
+  make \
+  unzip && apt-get clean
+
+RUN git clone https://github.com/grpc/grpc.git /var/local/git/grpc
+RUN cd /var/local/git/grpc && \
+  git pull --recurse-submodules && \
+  git submodule update --init --recursive
+
+RUN cd /var/local/git/grpc/third_party/protobuf && \
+  ./autogen.sh && \
+  ./configure --prefix=/usr && \
+  make -j12 && make check && make install && make clean
+
+RUN cd /var/local/git/grpc && make install

--- a/cxx/README.md
+++ b/cxx/README.md
@@ -1,0 +1,3 @@
+# grpc/cxx
+
+[`grpc/cxx`](https://index.docker.io/u/grpc/cxx) is a docker base image with the [gRPC C++ library](http://github.com/grpc/grpc) installed.

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM node:latest
+
+RUN apt-get update && apt-get install -y \
+  gcc \
+  git \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libgflags-dev \
+  libtool \
+  make && apt-get clean
+
+RUN git clone https://github.com/grpc/grpc.git /var/local/git/grpc
+RUN cd /var/local/git/grpc && \
+  git pull --recurse-submodules && \
+  git submodule update --init --recursive
+
+RUN cd /var/local/git/grpc && make install_c
+
+RUN npm install -g grpc

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,3 @@
+# grpc/node
+
+[`grpc/node`](https://index.docker.io/u/grpc/node) is a docker base image with Node.js and the [gRPC Node.js library](http://github.com/grpc/grpc/tree/master/src/node) installed.

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,0 +1,60 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM python:2.7
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  curl \
+  gcc \
+  git \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libgflags-dev \
+  libtool \
+  make \
+  unzip && apt-get clean
+
+RUN git clone https://github.com/grpc/grpc.git /var/local/git/grpc
+RUN cd /var/local/git/grpc && \
+  git pull --recurse-submodules && \
+  git submodule update --init --recursive
+
+RUN cd /var/local/git/grpc/third_party/protobuf && \
+  ./autogen.sh && \
+  ./configure --prefix=/usr && \
+  make -j12 && make check && make install && make clean
+
+RUN cd /var/local/git/grpc && make install_c
+
+RUN pip install enum34==1.0.4 futures==2.2.0 protobuf==3.0.0-alpha-1
+RUN cd /var/local/git/grpc && pip install src/python/src

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,3 @@
+# grpc/python
+
+[`grpc/python`](https://index.docker.io/u/grpc/python) is a docker base image with Python and the [gRPC Python library](http://github.com/grpc/grpc/tree/master/src/python) installed.

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,0 +1,90 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM debian:latest
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  automake \
+  autotools-dev \
+  bison \
+  build-essential \
+  curl \
+  g++ \
+  gawk \
+  gcc \
+  git \
+  libc6-dbg \
+  libc6-dev \
+  libffi-dev \
+  libgdbm-dev \
+  libgtest-dev \
+  libgflags-dev \
+  libncurses5-dev \
+  libreadline6-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libtool \
+  libyaml-dev \
+  make \
+  patch \
+  pkg-config \
+  procps \
+  sqlite3 \
+  unzip \
+  zlib1g-dev && apt-get clean
+
+# Install RVM, use this to install ruby
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3  # Needed for RVM
+RUN /bin/bash -l -c "curl -L get.rvm.io | bash -s stable"
+
+# Install Ruby 2.1
+RUN /bin/bash -l -c "rvm install ruby-2.1"
+RUN /bin/bash -l -c "rvm use --default ruby-2.1"
+RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.1' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
+
+RUN git clone https://github.com/grpc/grpc.git /var/local/git/grpc
+RUN cd /var/local/git/grpc && \
+  git pull --recurse-submodules && \
+  git submodule update --init --recursive
+
+# Build and install the protobuf library
+RUN cd /var/local/git/grpc/third_party/protobuf && \
+  ./autogen.sh && \
+  ./configure --prefix=/usr && \
+  make -j12 && make check && make install && make clean
+
+RUN cd /var/local/git/grpc && make install_c
+
+RUN cd /var/local/git/grpc/src/ruby && \
+  /bin/bash -l -c "gem build grpc.gemspec && gem install grpc"

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,3 @@
+# grpc/ruby
+
+[`grpc/ruby`](https://index.docker.io/u/grpc/ruby) is a docker base image with RVM, Ruby, and the [gRPC Ruby library](http://github.com/grpc/grpc/tree/master/src/ruby) installed.


### PR DESCRIPTION
These Dockerfiles are intended to be published to and built on the [online docker repository](http://registry.hub.docker.com). C++, Node, and Ruby all build successfully, and Python probably will after grpc/grpc#1054 is submitted.
