### PR TITLE
Remove default run command for Java

### DIFF
--- a/grpc_java/Dockerfile
+++ b/grpc_java/Dockerfile
@@ -35,6 +35,3 @@ RUN cd /var/local/git/grpc-java/lib/netty && \
   mvn -pl codec-http2 -am -DskipTests install clean
 RUN cd /var/local/git/grpc-java && \
   ./gradlew build
-
-# Specify the default command such that the interop server runs on its known testing port
-CMD ["/var/local/git/grpc-java/run-test-server.sh", "--use_tls=true", "--port=8030"]


### PR DESCRIPTION
The command doesn't make sense for normal users.
