### PR TITLE
Android Dockerfile

### DIFF
--- a/grpc_android/Dockerfile
+++ b/grpc_android/Dockerfile
@@ -1,0 +1,66 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Dockerfile for the gRPC Java dev image
+FROM grpc/java_base
+
+# Required by accessing Android's aapt
+RUN apt-get install -y lib32stdc++6 lib32z1 && apt-get clean
+
+# Install Android SDK 24.2
+RUN curl -L http://dl.google.com/android/android-sdk_r24.2-linux.tgz | tar xz -C /usr/local
+
+# Environment variables
+ENV ANDROID_HOME /usr/local/android-sdk-linux
+ENV PATH $PATH:$ANDROID_HOME/tools
+ENV PATH $PATH:$ANDROID_HOME/platform-tools
+# Some old Docker versions consider '/' as HOME
+ENV HOME /root
+
+# Update sdk for android 5.1 (API level 22)
+RUN echo y | android update sdk --all --filter platform-tools,build-tools-22.0.1,sys-img-armeabi-v7a-android-22,android-22,extra-android-m2repository,extra-google-m2repository --no-ui --force
+
+# Create an AVD with API level 22
+RUN echo no | android create avd --force -n avd-api-22 -t android-22
+
+# Pull gRPC Java and trigger download of needed Maven and Gradle artifacts.
+RUN git clone --depth 1 https://github.com/grpc/grpc-java.git /var/local/git/grpc-java && \
+  cd /var/local/git/grpc-java && \
+  ./gradlew grpc-core:install grpc-stub:install grpc-okhttp:install grpc-protobuf-nano:install && \
+  rm -r "$(pwd)"
+
+# Pull gRPC Android integration test App
+RUN git clone --depth 1 https://github.com/madongfly/grpc-android-test.git /var/local/git/grpc-android-test
+
+# Config android sdk for gradle
+RUN cd /var/local/git/grpc-android-test && echo "sdk.dir=/usr/local/android-sdk-linux" > local.properties
+
+# Build apks to trigger download of needed Maven and Gradle artifacts.
+RUN cd /var/local/git/grpc-android-test && ./gradlew assembleDebug
+RUN cd /var/local/git/grpc-android-test && ./gradlew assembleDebugAndroidTest

--- a/grpc_android/README.md
+++ b/grpc_android/README.md
@@ -1,0 +1,42 @@
+GRPC Android Dockerfile
+====================
+
+Dockerfile for creating the gRPC Android integration test image
+
+As of 2015/05 this
+ - is based on the gRPC Java base
+ - installs Android sdk 24.2
+ - creates an AVD for API level 22
+ - Pulls gRpc Android test App from github
+
+Usage
+-----
+
+Start the emulator in a detached container, the argument is the name of the AVD you want to start:
+
+```
+$ sudo docker run --name=grpc_android_test -d grpc/android /var/local/git/grpc-android-test/start-emulator.sh avd-api-22
+```
+
+You can use the following cammand to wait until the emulator is ready:
+```
+$ sudo docker exec grpc_android_test /var/local/git/grpc-android-test/wait-for-emulator.sh
+```
+
+When you want to update the apk, run:
+```
+$ sudo docker exec grpc_android_test /var/local/git/grpc-android-test/update-apk.sh
+```
+It will pull the fresh code of gRpc Java and our integration test app from github, build and install it to the runing emulator (so you need to make sure there is a runing emulator).
+
+Trigger the integration test:
+```
+$ sudo docker exec grpc_android_test /var/local/git/grpc-android-test/run-test.sh -e server_host <hostname or ip address> -e server_port 8030 -e server_host_override foo.test.google.fr -e use_tls true -e use_test_ca true
+```
+
+You can also use the android/adb cammands to get more info, such as:
+```
+$ sudo docker exec grpc_android_test android list avd
+$ sudo docker exec grpc_android_test adb devices
+$ sudo docker exec grpc_android_test adb logcat
+```


### PR DESCRIPTION
- based on the gRPC Java base
- installs Android sdk 24.2
- creates an AVD for API level 22
- pulls gRpc Android test App from github
