### PR TITLE
Remove the invocation to no longer existing python unit tests.

### DIFF
--- a/grpc_python/Dockerfile
+++ b/grpc_python/Dockerfile
@@ -54,7 +54,6 @@ RUN cd /var/local/git/grpc \
   && python2.7 -B -m grpc._adapter._lonely_rear_link_test \
   && python2.7 -B -m grpc._adapter._low_test \
   && python2.7 -B -m grpc.early_adopter.implementations_test \
-  && python2.7 -B -m grpc.framework.base.packets.implementations_test \
   && python2.7 -B -m grpc.framework.face.blocking_invocation_inline_service_test \
   && python2.7 -B -m grpc.framework.face.event_invocation_synchronous_event_service_test \
   && python2.7 -B -m grpc.framework.face.future_invocation_asynchronous_event_service_test \


### PR DESCRIPTION
The docker file is executing python tests by referring to each of them
explicitly. This is fragile as the unit tests in the main repository
could change overtime.

Instead, this change patches the dockerfile to use a Makefile target that
executes python tests.
