### PR TITLE
Remove nodejs-legacy #12

### DIFF
--- a/grpc_node_base/Dockerfile
+++ b/grpc_node_base/Dockerfile
@@ -34,7 +34,7 @@ FROM grpc/base
 
 RUN curl -sL https://deb.nodesource.com/setup | bash -
 
-RUN apt-get update && apt-get install -y nodejs nodejs-legacy
+RUN apt-get update && apt-get install -y nodejs
 
 RUN npm install -g node-gyp
 


### PR DESCRIPTION
Remove nodejs-legacy as it is redundant.
