### PR TITLE
Update protobuf version to 3.0.0-alpha-3

### DIFF
--- a/grpc_java_base/Dockerfile
+++ b/grpc_java_base/Dockerfile
@@ -51,9 +51,9 @@ ENV PATH $PATH:$JAVA_HOME/bin:$M2_HOME/bin
 ENV LD_LIBRARY_PATH /usr/local/lib
 
 # Get the protobuf source from GitHub and install it
-RUN wget -O - https://github.com/google/protobuf/archive/v3.0.0-alpha-2.tar.gz | \
+RUN wget -O - https://github.com/google/protobuf/archive/v3.0.0-alpha-3.tar.gz | \
   tar xz && \
-  cd protobuf-3.0.0-alpha-2 && \
+  cd protobuf-3.0.0-alpha-3 && \
   ./autogen.sh && \
   ./configure --prefix=/usr && \
   make -j12 && make check && make install && \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -56,5 +56,5 @@ RUN cd /var/local/git/grpc/third_party/protobuf && \
 
 RUN cd /var/local/git/grpc && make install_c
 
-RUN pip install enum34==1.0.4 futures==2.2.0 protobuf==3.0.0-alpha-1
+RUN pip install enum34==1.0.4 futures==2.2.0 protobuf==3.0.0a3
 RUN cd /var/local/git/grpc && pip install src/python/src


### PR DESCRIPTION
There's some protobuf left out in #11 

This pull request updates them.

```
# grep -R "3.0.0" .
./grpc_java_base/Dockerfile:RUN wget -O - https://github.com/google/protobuf/archive/v3.0.0-alpha-2.tar.gz | \
./grpc_java_base/Dockerfile:  cd protobuf-3.0.0-alpha-2 && \
./grpc_python_base/Dockerfile:RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a3
./python/Dockerfile:RUN pip install enum34==1.0.4 futures==2.2.0 protobuf==3.0.0-alpha-1
```
