### PR TITLE
Remove manual build for netty-codec-http2

### DIFF
--- a/grpc_java/Dockerfile
+++ b/grpc_java/Dockerfile
@@ -31,7 +31,5 @@
 FROM grpc/java_base
 
 RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git /var/local/git/grpc-java
-RUN cd /var/local/git/grpc-java/lib/netty && \
-  mvn -pl codec-http2 -am -DskipTests install clean
 RUN cd /var/local/git/grpc-java && \
   ./gradlew build

--- a/grpc_java_base/Dockerfile
+++ b/grpc_java_base/Dockerfile
@@ -62,8 +62,6 @@ RUN wget -O - https://github.com/google/protobuf/archive/v3.0.0-alpha-2.tar.gz |
 # Trigger download of as many Maven and Gradle artifacts as possible. We don't build grpc-java
 # because we don't want to install netty
 RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git && \
-  cd grpc-java/lib/netty && \
-  mvn -pl codec-http2 -am -DskipTests verify && \
-  cd ../.. && \
+  cd grpc-java && \
   ./gradlew && \
   rm -r "$(pwd)"


### PR DESCRIPTION
Current build of `grpc_java_base` (and `grpc_java`) will hit the following error

```
Step 12 : RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git &&   cd grpc-java/lib/netty &&   mvn -pl codec-http2 -am -DskipTests verify &&   cd ../.. &&   ./gradlew &&   rm -r "$(pwd)"
 ---> Running in 70736ecbce5e
Cloning into 'grpc-java'...
/bin/sh: 1: cd: can't cd to grpc-java/lib/netty
INFO[1186] The command [/bin/sh -c git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git &&   cd grpc-java/lib/netty &&   mvn -pl codec-http2 -am -DskipTests verify &&   cd ../.. &&   ./gradlew &&   rm -r "$(pwd)"] returned a non-zero code: 2 
```

The reason is the `grpc-java/lib` folder has been removed in grpc/grpc-java@652abe2f63fa6a797221cea48000ec3e662fa1e0 and instead of relying upon maven in grpc/grpc-java@5df6ab00da65e4c6148e4164d9db1a12e28e5175

Hence, there is no need to perform manual maven build locally for `netty-codec-http2`

Identified two Dockerfile involved.

```
$ grep -R "codec-http2" .
./grpc_java/Dockerfile:  mvn -pl codec-http2 -am -DskipTests install clean
./grpc_java_base/Dockerfile:  mvn -pl codec-http2 -am -DskipTests verify && \
```
