### PR TITLE
Updates the 0.10 Dockerfiles to pin the grpc debian version

### DIFF
--- a/0.10/cxx/Dockerfile
+++ b/0.10/cxx/Dockerfile
@@ -27,13 +27,33 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM ruby:2.2
+FROM buildpack-deps:jessie
 
-RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  curl \
+  gcc \
+  git \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libgflags-dev \
+  libtool \
+  make \
+  unzip && apt-get clean
 
-ENV GRPC_VERSION 0.10.2-1~bpo8+1
-ENV GRPC_RUBY_VERSION 0.10.0
+ENV GRPC_RELEASE_TAG release-0_10_2
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN git clone https://github.com/grpc/grpc.git /var/local/git/grpc
+RUN cd /var/local/git/grpc && \
+  git checkout tags/${GRPC_RELEASE_TAG} && \
+  git submodule update --init --recursive
 
-RUN gem install grpc -v ${GRPC_RUBY_VERSION}
+RUN cd /var/local/git/grpc/third_party/protobuf && \
+  ./autogen.sh && \
+  ./configure --prefix=/usr && \
+  make -j12 && make check && make install && make clean
+
+RUN cd /var/local/git/grpc && make install

--- a/0.10/cxx/README.md
+++ b/0.10/cxx/README.md
@@ -1,0 +1,14 @@
+# gRPC C++ Docker image
+
+This is the official docker image for the C++ installation of [grpc][].  For an
+overview and usage examples, see the [grpc C++ documentation][].
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official [gRPC documentation][].
+
+[grpc]:http:/grpc.io
+[grpc documentation]:http://www.grpc.io/docs/
+[grpc C++ documentation]:http://www.grpc.io/docs/tutorials/basic/c.html

--- a/0.10/node/Dockerfile
+++ b/0.10/node/Dockerfile
@@ -31,6 +31,9 @@ FROM node:0.12.7
 
 RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev
+ENV GRPC_VERSION 0.10.2-1~bpo8+1
+ENV GRPC_NODE_VERSION 0.10.1
 
-RUN npm install -g grpc@0.10.1
+RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+
+RUN npm install -g grpc@${GRPC_NODE_VERSION}

--- a/0.10/php/Dockerfile
+++ b/0.10/php/Dockerfile
@@ -31,7 +31,8 @@ FROM php:5.5
 
 RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list
 
+ENV GRPC_VERSION 0.10.2-1~bpo8+1
 
-RUN apt-get update && apt-get install -y -q php5 php5-dev phpunit php-pear libgrpc-dev
+RUN apt-get update && apt-get install -y -q php5 php5-dev phpunit php-pear libgrpc-dev=${GRPC_VERSION}
 
 RUN pecl install grpc-alpha

--- a/0.10/python/Dockerfile
+++ b/0.10/python/Dockerfile
@@ -31,6 +31,9 @@ FROM python:2.7.10
 
 RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev
+ENV GRPC_VERSION 0.10.2-1~bpo8+1
+ENV GRPC_PYTHON_VERSION 0.10.0a0
 
-RUN pip install grpcio==0.10.0a0
+RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+
+RUN pip install grpcio==${GRPC_PYTHON_VERSION}


### PR DESCRIPTION
- Ensures that the 0.10 builds are repeatable, and establishes the pattern for future updates
- Also:
  - introduces ENV vars where possible to minimize risk of maintenance typos
  - adds a 0.10 version of the cxx docker image
