### PR TITLE
Adds some onbuild packages

### DIFF
--- a/0.10/node/README.md
+++ b/0.10/node/README.md
@@ -1,13 +1,46 @@
 # gRPC Node.js Docker image
 
-This is the official docker image for the Node.js library of [grpc][].  For an
-overview and usage examples, see the [grpc nodejs documentation][].
+This is the official docker image for the Node.js library of grpc.  For an
+overview and usage examples, see the grpc nodejs documentation.
 
 # What is gRPC ?
 
 A high performance, open source, general RPC framework that puts mobile and
 HTTP/2 first, available in many programming languages.  For full details, see
-the official [gRPC documentation][].
+the official gRPC documentation.
+
+# How to use this image
+
+## Create a `Dockerfile` in your gRPC Node.js app project
+
+```dockerfile
+FROM grpc/node:0.10-onbuild
+# replace this with your application's default port
+EXPOSE 8888
+```
+
+You can then build and run the Docker image:
+
+```console
+$ docker build -t my-grpc-nodejs-client-or-server .
+$ docker run -it --rm --name my-running-app my-grpc-nodejs-client-or-server
+```
+
+## Notes
+
+The image assumes that your application has a file named `package.json` listing
+its dependencies and defining its start script
+
+## Run a single Node.js script
+
+For many simple, single file projects, you may find it inconvenient to write a
+`complete `Dockerfile`. In such cases, you can run a Node.js script by using the
+Node.js Docker image directly:
+
+```console
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp grpc/node:0.10 node your-grpc-client-or-server.js
+```
+
 
 [grpc]:http:/grpc.io
 [grpc documentation]:http://www.grpc.io/docs/

--- a/0.10/node/onbuild/Dockerfile
+++ b/0.10/node/onbuild/Dockerfile
@@ -1,0 +1,10 @@
+FROM grpc/node:0.10
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY package.json /usr/src/app/
+ONBUILD RUN npm install
+ONBUILD COPY . /usr/src/app
+
+CMD [ "npm", "start" ]

--- a/0.10/python/README.md
+++ b/0.10/python/README.md
@@ -1,13 +1,47 @@
 # gRPC Python Docker image
 
-This is the official docker image for the Python facility of [grpc][].  For an
-overview and usage examples, see the [grpc python documentation][].
+This is the official docker image for the Python facility of grpc.  For an
+overview and usage examples, see the grpc python documentation.
 
 # What is gRPC ?
 
 A high performance, open source, general RPC framework that puts mobile and
 HTTP/2 first, available in many programming languages.  For full details, see
-the official [gRPC documentation][].
+the official gRPC documentation.
+
+
+# How to use this image
+
+## Create a `Dockerfile` in your Python app project
+
+
+```dockerfile
+FROM grpc/python:0.10-onbuild
+CMD [ "python", "./your-daemon-or-script.py" ]
+```
+
+These images include multiple `ONBUILD` triggers, which should be all you need
+to bootstrap most applications. The build will `COPY` a `requirements.txt` file,
+`RUN pip install` on said file, and then copy the current directory into
+`/usr/src/app`.
+
+You can then build and run the Docker image:
+
+```console
+$ docker build -t my-grpc-python-client-or-server .
+$ docker run -it --rm --name my-running-app my-grpc-python-client-or-server
+```
+
+## Run a single Python script
+
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Python script by using the
+Python Docker image directly:
+
+
+```console
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp grpc/python:0.10 python your-grpc-python-client-or-server.py
+```
 
 [grpc]:http:/grpc.io
 [grpc documentation]:http://www.grpc.io/docs/

--- a/0.10/python/onbuild/Dockerfile
+++ b/0.10/python/onbuild/Dockerfile
@@ -1,0 +1,9 @@
+FROM grpc/python:0.10
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY requirements.txt /usr/src/app/
+ONBUILD RUN pip install --no-cache-dir -r requirements.txt
+
+ONBUILD COPY . /usr/src/app

--- a/0.10/ruby/README.md
+++ b/0.10/ruby/README.md
@@ -1,13 +1,58 @@
 # gRPC Ruby Docker image
 
-This is the official docker image for the Ruby library of [grpc][].  For an
-overview and usage examples, see the [grpc ruby documentation][].
+This is the official docker image for the Ruby library of grpc.  For an
+overview and usage examples, see the grpc ruby documentation.
 
 # What is gRPC ?
 
 A high performance, open source, general RPC framework that puts mobile and
 HTTP/2 first, available in many programming languages.  For full details, see
-the official [gRPC documentation][].
+the official gRPC documentation.
+
+# How to use this image
+
+## Create a `Dockerfile` in your gRPC Ruby app project
+
+```dockerfile
+FROM grpc/ruby:0.10-onbuild
+CMD ["./your-client-or-server.rb"]
+```
+
+Put this file in the root of your app, next to the `Gemfile`.
+
+This image includes multiple `ONBUILD` triggers which should be all you need to
+bootstrap most gRPC Ruby applications. The build will `COPY . /usr/src/app` and
+`RUN bundle install`.
+
+You can then build and run the Ruby image:
+
+```console
+$ docker build -t my-ruby-app .
+$ docker run -it --name my-running-script my-ruby-app
+```
+
+### Generate a `Gemfile.lock`
+
+The `onbuild` tag expects a `Gemfile.lock` in your app directory. This `docker
+run` will help you generate one. Run it in the root of your app, next to the
+`Gemfile`:
+
+
+```console
+$ docker run --rm -v "$PWD":/usr/src/app -w /usr/src/app grpc/ruby:0.10 bundle install
+```
+
+## Run a single Ruby script
+
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a gRPC Ruby app by using the
+gRPC Ruby Docker image directly:
+
+
+```console
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp grpc/ruby:0.10 ruby your-grpc-client-or-server.rb
+```
+
 
 [grpc]:http:/grpc.io
 [grpc documentation]:http://www.grpc.io/docs/

--- a/0.10/ruby/onbuild/Dockerfile
+++ b/0.10/ruby/onbuild/Dockerfile
@@ -1,0 +1,13 @@
+FROM grpc/ruby:0.10
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY Gemfile /usr/src/app/
+ONBUILD COPY Gemfile.lock /usr/src/app/
+ONBUILD RUN bundle install
+
+ONBUILD COPY . /usr/src/app


### PR DESCRIPTION
- adds onbuild packages similar to the ones available for the language docker repos
- these allow easy experimentation with gRPC as long as docker is available
- these can be used to provide an alternative installation path for the Quick Starts
