### PR TITLE
Updates the golang dockerfile

### DIFF
--- a/0.10/golang/Dockerfile
+++ b/0.10/golang/Dockerfile
@@ -30,15 +30,9 @@
 # Dockerfile for gRPC Go
 FROM golang:1.4
 
+# NOTE: for now, this docker image always builds the current HEAD version of
+# gRPC.  After gRPC's beta release, the Dockerfile versions will be updated to
+# build a specific version.
+
 # Get the source from GitHub
 RUN go get google.golang.org/grpc
-
-# Add a service_account directory containing the auth creds file
-ADD service_account service_account
-
-# Build the interop client and server
-RUN cd src/google.golang.org/grpc/interop/client && go install
-RUN cd src/google.golang.org/grpc/interop/server && go install
-
-# Specify the default command such that the interop server runs on its known testing port
-CMD ["/bin/bash", "-c", "cd src/google.golang.org/grpc/interop/server && go run server.go --use_tls=true --port=8020"]

--- a/0.10/golang/README.md
+++ b/0.10/golang/README.md
@@ -1,0 +1,11 @@
+# gRPC Go Docker image
+======================
+
+This is the official docker image for grpc Go.  For an overview and usage
+examples, see the grpc Go documentation.
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official gRPC documentation.

--- a/grpc_go/README.md
+++ b/grpc_go/README.md
@@ -1,4 +1,0 @@
-GRPC Go Dockerfile
-==================
-
-Dockerfile for gRPC Go development, testing and deployment.


### PR DESCRIPTION
- moves the Dockerfile to match with official repo versioning dir structure
- updates the README
- simplifies the dockerfile so that the image just has gRPC source code
  present, but does not have anything built
