### PR TITLE
Include protoc with the Go gRPC image.

### DIFF
--- a/0.11/golang/Dockerfile
+++ b/0.11/golang/Dockerfile
@@ -30,6 +30,20 @@
 # Dockerfile for gRPC Go
 FROM golang:1.4
 
+# install protobuf from source
+RUN apt-get update && \
+    apt-get -y install git unzip build-essential autoconf libtool
+RUN git clone https://github.com/google/protobuf.git && \
+    cd protobuf && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig && \
+    make clean && \
+    cd .. && \
+    rm -r protobuf
+
 # NOTE: for now, this docker image always builds the current HEAD version of
 # gRPC.  After gRPC's beta release, the Dockerfile versions will be updated to
 # build a specific version.


### PR DESCRIPTION
Downloads and compiles protoc to include it in the image, to make development easier.
