### PR TITLE
Add protoc-gen-go to grpc/go

### DIFF
--- a/0.11/golang/Dockerfile
+++ b/0.11/golang/Dockerfile
@@ -50,3 +50,5 @@ RUN git clone https://github.com/google/protobuf.git && \
 
 # Get the source from GitHub
 RUN go get google.golang.org/grpc
+# Install protoc-gen-go
+RUN go get github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
Currently protoc-gen-go is not available, which means compiling any `.proto` to go produces this error:

```
$ protoc --go_out=. helloworld.proto
protoc-gen-go: program not found or is not executable
--go_out: protoc-gen-go: Plugin failed with status code 1.
```
