### PR TITLE
Add gRPC 1.4 and Python 3.6 support

### DIFF
--- a/1.4/python/Dockerfile
+++ b/1.4/python/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.6
+
+ENV GRPC_PYTHON_VERSION 1.4.0
+RUN python -m pip install --upgrade pip
+RUN pip install grpcio==${GRPC_PYTHON_VERSION} grpcio-tools==${GRPC_PYTHON_VERSION}

--- a/1.4/python/README.md
+++ b/1.4/python/README.md
@@ -1,0 +1,49 @@
+# gRPC Python Docker image
+
+This is the official docker image for the Python facility of [gRPC][grpc].
+For an overview and usage examples, see the 
+[gRPC Python documentation][grpc python documentation].
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official [gRPC][grpc documentation] documentation.
+
+
+# How to use this image
+
+## Create a `Dockerfile` in your Python app project
+
+
+```dockerfile
+FROM grpc/python:1.4-onbuild
+CMD [ "python", "./your-daemon-or-script.py" ]
+```
+
+These images include multiple `ONBUILD` triggers, which should be all you need
+to bootstrap most applications. The build will `COPY` a `requirements.txt` file,
+`RUN pip install` on said file, and then copy the current directory into
+`/usr/src/app`.
+
+You can then build and run the Docker image:
+
+```console
+$ docker build -t my-grpc-python-client-or-server .
+$ docker run -it --rm --name my-running-app my-grpc-python-client-or-server
+```
+
+## Run a single Python script
+
+For many simple, single file projects, you may find it inconvenient to write a
+complete `Dockerfile`. In such cases, you can run a Python script by using the
+Python Docker image directly:
+
+
+```console
+$ docker run -it --rm --name my-running-script -v "$PWD":/usr/src/myapp -w /usr/src/myapp grpc/python:1.4 python your-grpc-python-client-or-server.py
+```
+
+[grpc]:http:/grpc.io
+[grpc documentation]:http://www.grpc.io/docs/
+[grpc python documentation]:http://www.grpc.io/docs/tutorials/basic/python.html

--- a/1.4/python/onbuild/Dockerfile
+++ b/1.4/python/onbuild/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM grpc/python:1.4
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY requirements.txt /usr/src/app/
+ONBUILD RUN pip install --no-cache-dir -r requirements.txt
+
+ONBUILD COPY . /usr/src/app


### PR DESCRIPTION
This PR is related to https://github.com/grpc/grpc-docker-library/issues/45. The new `1.4` folder contains a Dockerfile that implements gRPC 1.4 for Python 3.6.

Happy to change anything! Let me know your thoughts and feedback 😄 