### PR TITLE
Protobuf include directory

### DIFF
--- a/1.0/golang/Dockerfile
+++ b/1.0/golang/Dockerfile
@@ -37,7 +37,8 @@ RUN mkdir -p /tmp/protoc && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip > /tmp/protoc/protoc.zip && \
     cd /tmp/protoc && \
     unzip protoc.zip && \
-    cp -R /tmp/protoc/* /usr/local/ && \
+    cp /tmp/protoc/bin/protoc /usr/local/bin && \
+    cp -R /tmp/protoc/include/* /usr/local/include && \
     chmod go+rx /usr/local/bin/protoc && \
     cd /tmp && \
     rm -r /tmp/protoc

--- a/1.0/golang/Dockerfile
+++ b/1.0/golang/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p /tmp/protoc && \
     curl -L https://github.com/google/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip > /tmp/protoc/protoc.zip && \
     cd /tmp/protoc && \
     unzip protoc.zip && \
-    cp /tmp/protoc/bin/protoc /usr/local/bin && \
+    cp -R /tmp/protoc/* /usr/local/ && \
     chmod go+rx /usr/local/bin/protoc && \
     cd /tmp && \
     rm -r /tmp/protoc


### PR DESCRIPTION
The current build only copies the `protoc/bin/protoc` binary from the protobuf release.  This doesn't allow for any protoc compilation that requires the standard `google.protobuf` includes.  Changed the copy function to copy everything to /usr/local which includes the `bin` directory and the `include` directory.