### PR TITLE
Update Dockerfile

### DIFF
--- a/1.0/cxx/Dockerfile
+++ b/1.0/cxx/Dockerfile
@@ -39,12 +39,16 @@ ENV GRPC_RELEASE_TAG v1.0.0
 
 RUN git clone -b ${GRPC_RELEASE_TAG} https://github.com/grpc/grpc /var/local/git/grpc
 
+#install protoc
+RUN git clone https://github.com/google/protobuf.git 
+RUN cd protobuf && \
+    ./autogen.sh && ./configure && \
+    make && make check && make install && \
+    ldconfig && \
+    make && make install && make clean
+    
 # install grpc
 RUN cd /var/local/git/grpc && \
     git submodule update --init && \
     make && \
     make install && make clean
-
-#install protoc
-RUN cd /var/local/git/grpc/third_party/protobuf && \
-    make && make install && make clean


### PR DESCRIPTION
I want to know why it should install grpc first.On the contrary, the grpc related to protobuf so why not install protobuf first.Thanks for your answer and I just give an advice and come up a question.