### PR TITLE
Update C++ Docker image to gRPC 1.8

### DIFF
--- a/1.8/cxx/Dockerfile
+++ b/1.8/cxx/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y \
+  build-essential autoconf libtool git pkg-config curl \
+  automake libtool curl make g++ unzip \
+  && apt-get clean
+
+# install protobuf first, then grpc
+ENV GRPC_RELEASE_TAG v1.8.x
+RUN git clone -b ${GRPC_RELEASE_TAG} https://github.com/grpc/grpc /var/local/git/grpc && \
+		cd /var/local/git/grpc && \
+    git submodule update --init && \
+    echo "--- installing protobuf ---" && \
+    cd third_party/protobuf && \
+    ./autogen.sh && ./configure --enable-shared && \
+    make -j && make -j check && make install && make clean && ldconfig && \
+    echo "--- installing grpc ---" && \
+    cd /var/local/git/grpc && \
+    make -j && make install && make clean && ldconfig

--- a/1.8/cxx/README.md
+++ b/1.8/cxx/README.md
@@ -1,0 +1,14 @@
+# gRPC C++ Docker image
+
+This is the official docker image for the C++ installation of [gRPC][].  For an
+overview and usage examples, see the [gRPC C++ documentation][].
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official [gRPC documentation][].
+
+[grpc]:http:/grpc.io
+[grpc documentation]:http://www.grpc.io/docs/
+[grpc C++ documentation]:http://www.grpc.io/docs/tutorials/basic/c.html


### PR DESCRIPTION
This makes sure there are both static and dynamic libraries installed for protobuf and grpc.

Also use parallel building to make build time much faster.