### PR TITLE
Fix release versions of 'protoc-gen-go' and 'google.golang.org/grpc'

### DIFF
--- a/1.0/golang/Dockerfile
+++ b/1.0/golang/Dockerfile
@@ -47,11 +47,11 @@ RUN mkdir -p /tmp/protoc && \
 
 # Get the source from GitHub
 RUN mkdir -p /tmp/grpc-go && \
-    curl -L https://github.com/grpc/grpc-go/archive/v1.13.0.zip > /tmp/grpc-go/grpc-go.zip && \
+    curl -L https://github.com/grpc/grpc-go/archive/v1.0.0.zip > /tmp/grpc-go/grpc-go.zip && \
     cd /tmp/grpc-go && \
     unzip grpc-go.zip && \
     mkdir -p /go/src/google.golang.org/grpc/ && \
-    cp -r /tmp/grpc-go/grpc-go-1.13.0/* /go/src/google.golang.org/grpc/
+    cp -r /tmp/grpc-go/grpc-go-1.0.0/* /go/src/google.golang.org/grpc/
 
 # Install protoc-gen-go
 RUN mkdir -p /tmp/protobuf && \
@@ -61,4 +61,3 @@ RUN mkdir -p /tmp/protobuf && \
     mkdir -p /go/src/github.com/golang/protobuf/ && \
     cp -r /tmp/protobuf/protobuf-1.1.0/* /go/src/github.com/golang/protobuf/ && \
     go install github.com/golang/protobuf/protoc-gen-go
-

--- a/1.0/golang/Dockerfile
+++ b/1.0/golang/Dockerfile
@@ -46,6 +46,19 @@ RUN mkdir -p /tmp/protoc && \
     rm -r /tmp/protoc
 
 # Get the source from GitHub
-RUN go get google.golang.org/grpc
+RUN mkdir -p /tmp/grpc-go && \
+    curl -L https://github.com/grpc/grpc-go/archive/v1.13.0.zip > /tmp/grpc-go/grpc-go.zip && \
+    cd /tmp/grpc-go && \
+    unzip grpc-go.zip && \
+    mkdir -p /go/src/google.golang.org/grpc/ && \
+    cp -r /tmp/grpc-go/grpc-go-1.13.0/* /go/src/google.golang.org/grpc/
+
 # Install protoc-gen-go
-RUN go get github.com/golang/protobuf/protoc-gen-go
+RUN mkdir -p /tmp/protobuf && \
+    curl -L https://github.com/golang/protobuf/archive/v1.1.0.zip > /tmp/protobuf/protobuf.zip && \
+    cd /tmp/protobuf && \
+    unzip protobuf.zip && \
+    mkdir -p /go/src/github.com/golang/protobuf/ && \
+    cp -r /tmp/protobuf/protobuf-1.1.0/* /go/src/github.com/golang/protobuf/ && \
+    go install github.com/golang/protobuf/protoc-gen-go
+

--- a/1.0/golang/Dockerfile
+++ b/1.0/golang/Dockerfile
@@ -28,12 +28,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # Dockerfile for gRPC Go
-FROM golang:1.7
+FROM golang:1.10
 
 RUN apt-get update && apt-get -y install unzip && apt-get clean
 
 # install protobuf
-ENV PB_VER 3.1.0
+ENV PB_VER 3.6.0
 ENV PB_URL https://github.com/google/protobuf/releases/download/v${PB_VER}/protoc-${PB_VER}-linux-x86_64.zip
 RUN mkdir -p /tmp/protoc && \
     curl -L ${PB_URL} > /tmp/protoc/protoc.zip && \


### PR DESCRIPTION
My team and I are currently using your `grpc/go:1.0` docker image to generate go code from our proto files.

We found an issue where you had published multiple versions of the `1.0` tag that each had a different versions of protoc-gen-go. This meant that different members on my team were generating slightly different code from the same proto file. (each person had a different version of `1.0` in their local docker cache).

I've provided a fix for the Dockerimage that installs the `protoc-gen-go`/`grpc` dependencies from stable release builds instead.