### PR TITLE
Add Go Dockerfile for v1.14.0

### DIFF
--- a/1.14.0/golang/Dockerfile
+++ b/1.14.0/golang/Dockerfile
@@ -1,0 +1,65 @@
+# Copyright 2016, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Dockerfile for gRPC Go
+FROM golang:1.11
+
+RUN apt-get update && apt-get -y install unzip && apt-get clean
+
+# install protobuf
+ENV PB_VER 3.6.1
+ENV PB_URL https://github.com/google/protobuf/releases/download/v${PB_VER}/protoc-${PB_VER}-linux-x86_64.zip
+RUN mkdir -p /tmp/protoc && \
+    curl -L ${PB_URL} > /tmp/protoc/protoc.zip && \
+    cd /tmp/protoc && \
+    unzip protoc.zip && \
+    cp /tmp/protoc/bin/protoc /usr/local/bin && \
+    cp -R /tmp/protoc/include/* /usr/local/include && \
+    chmod go+rx /usr/local/bin/protoc && \
+    cd /tmp && \
+    rm -r /tmp/protoc
+
+# Get the source from GitHub
+ENV GO_GRPC_VER 1.14.0
+RUN mkdir -p /tmp/grpc-go && \
+    curl -L https://github.com/grpc/grpc-go/archive/v${GO_GRPC_VER}.zip > /tmp/grpc-go/grpc-go.zip && \
+    cd /tmp/grpc-go && \
+    unzip grpc-go.zip && \
+    mkdir -p /go/src/google.golang.org/grpc/ && \
+    cp -r /tmp/grpc-go/grpc-go-${GO_GRPC_VER}/* /go/src/google.golang.org/grpc/
+
+# Install protoc-gen-go
+ENV GO_PROTOBUF_VER 1.2.0
+RUN mkdir -p /tmp/protobuf && \
+    curl -L https://github.com/golang/protobuf/archive/v${GO_PROTOBUF_VER}.zip > /tmp/protobuf/protobuf.zip && \
+    cd /tmp/protobuf && \
+    unzip protobuf.zip && \
+    mkdir -p /go/src/github.com/golang/protobuf/ && \
+    cp -r /tmp/protobuf/protobuf-${GO_PROTOBUF_VER}/* /go/src/github.com/golang/protobuf/ && \
+    go install github.com/golang/protobuf/protoc-gen-go

--- a/1.14.0/golang/README.md
+++ b/1.14.0/golang/README.md
@@ -1,0 +1,11 @@
+# gRPC Go Docker image
+======================
+
+This is the official docker image for gRPC Go.  For an overview and usage
+examples, see the gRPC Go documentation.
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official gRPC documentation.


### PR DESCRIPTION
Adding a Go Dockerfile for v1.14.0. I needed to upgrade from v1.0 in order to be able to build Go gRPC bindings.