### PR TITLE
Add GRPC v1.21.x CXX

### DIFF
--- a/1.21.0/cxx/Dockerfile
+++ b/1.21.0/cxx/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y \
+  build-essential autoconf libtool git pkg-config curl \
+  automake libtool curl make g++ unzip \
+  && apt-get clean
+
+# install protobuf first, then grpc
+ENV GRPC_RELEASE_TAG v1.21.x
+RUN git clone -b ${GRPC_RELEASE_TAG} https://github.com/grpc/grpc /var/local/git/grpc && \
+    cd /var/local/git/grpc && \
+    git submodule update --init && \
+    echo "--- installing protobuf ---" && \
+    cd third_party/protobuf && \
+    git submodule update --init && \
+    ./autogen.sh && ./configure --enable-shared && \
+    make -j$(nproc) && make -j$(nproc) check && make install && make clean && ldconfig && \
+    echo "--- installing grpc ---" && \
+    cd /var/local/git/grpc && \
+    make -j$(nproc) && make install && make clean && ldconfig && \
+    rm -rf /var/local/git/grpc

--- a/1.21.0/cxx/README.md
+++ b/1.21.0/cxx/README.md
@@ -1,0 +1,14 @@
+# gRPC C++ Docker image
+
+This is the official docker image for the C++ installation of [gRPC][].  For an
+overview and usage examples, see the [gRPC C++ documentation][].
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official [gRPC documentation][].
+
+[grpc]:http:/grpc.io
+[grpc documentation]:http://www.grpc.io/docs/
+[grpc C++ documentation]:http://www.grpc.io/docs/tutorials/basic/c.html


### PR DESCRIPTION
Protobuf had to have submodule update added to it, in order for make check to successfully build. As a result I've deleted the grpc github directory on the container as this results in an even larger image (1.8GB+) if this isn't completed.