### PR TITLE
Add gRPC 1.24.2 with Go 1.13, protobuf 3.10.0, and protoc-gen-go 1.3.2

### DIFF
--- a/1.24.0/golang/Dockerfile
+++ b/1.24.0/golang/Dockerfile
@@ -1,0 +1,50 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Dockerfile for gRPC Go
+FROM golang:1.13
+
+RUN apt-get update -y && apt-get -y install unzip && apt-get clean
+
+# Install protobuf
+ENV PB_VER 3.10.0
+ENV PB_URL https://github.com/google/protobuf/releases/download/v${PB_VER}/protoc-${PB_VER}-linux-x86_64.zip
+RUN mkdir -p /tmp/protoc && \
+    curl -L ${PB_URL} > /tmp/protoc/protoc.zip && \
+    cd /tmp/protoc && \
+    unzip protoc.zip && \
+    cp /tmp/protoc/bin/protoc /usr/local/bin && \
+    cp -R /tmp/protoc/include/* /usr/local/include && \
+    chmod go+rx /usr/local/bin/protoc && \
+    cd /tmp && \
+    rm -r /tmp/protoc
+
+# Get the source from GitHub
+ENV GRPC_GO_VER 1.24.0
+RUN mkdir -p /tmp/grpc-go && \
+    curl -L https://github.com/grpc/grpc-go/archive/v${GRPC_GO_VER}.zip > /tmp/grpc-go/grpc-go.zip && \
+    cd /tmp/grpc-go && \
+    unzip grpc-go.zip && \
+    mkdir -p /go/src/google.golang.org/grpc/ && \
+    cp -r /tmp/grpc-go/grpc-go-${GRPC_GO_VER}/* /go/src/google.golang.org/grpc/
+
+# Install protoc-gen-go
+ENV GO_PB_VER 1.3.2
+RUN mkdir -p /tmp/protobuf && \
+    curl -L https://github.com/golang/protobuf/archive/v${GO_PB_VER}.zip > /tmp/protobuf/protobuf.zip && \
+    cd /tmp/protobuf && ls && \
+    unzip protobuf.zip && \
+    mkdir -p /go/src/github.com/golang/protobuf/ && \
+    cp -r /tmp/protobuf/protobuf-${GO_PB_VER}/* /go/src/github.com/golang/protobuf/ && \
+    go install github.com/golang/protobuf/protoc-gen-go

--- a/1.24.0/golang/README.md
+++ b/1.24.0/golang/README.md
@@ -1,0 +1,11 @@
+# gRPC Go Docker image
+======================
+
+This is the official docker image for gRPC Go.  For an overview and usage
+examples, see the gRPC Go documentation.
+
+# What is gRPC ?
+
+A high performance, open source, general RPC framework that puts mobile and
+HTTP/2 first, available in many programming languages.  For full details, see
+the official gRPC documentation.


### PR DESCRIPTION
Added environment variables to make subsequent updates a bit easier as well.
