### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/0.10/cxx/Dockerfile
+++ b/0.10/cxx/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM buildpack-deps:jessie
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   autoconf \
   autotools-dev \
   build-essential \

--- a/0.10/node/Dockerfile
+++ b/0.10/node/Dockerfile
@@ -34,6 +34,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 ENV GRPC_VERSION 0.10.2-1~bpo8+1
 ENV GRPC_NODE_VERSION 0.10.1
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN npm install -g grpc@${GRPC_NODE_VERSION}

--- a/0.10/php/Dockerfile
+++ b/0.10/php/Dockerfile
@@ -33,6 +33,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 
 ENV GRPC_VERSION 0.10.2-1~bpo8+1
 
-RUN apt-get update && apt-get install -y -q php5 php5-dev phpunit php-pear libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q php5 php5-dev phpunit php-pear libgrpc-dev=${GRPC_VERSION}
 
 RUN pecl install grpc-alpha

--- a/0.10/python/Dockerfile
+++ b/0.10/python/Dockerfile
@@ -34,6 +34,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 ENV GRPC_VERSION 0.10.2-1~bpo8+1
 ENV GRPC_PYTHON_VERSION 0.10.0a0
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN pip install grpcio==${GRPC_PYTHON_VERSION}

--- a/0.10/ruby/Dockerfile
+++ b/0.10/ruby/Dockerfile
@@ -34,6 +34,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 ENV GRPC_VERSION 0.10.2-1~bpo8+1
 ENV GRPC_RUBY_VERSION 0.10.0
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN gem install grpc -v ${GRPC_RUBY_VERSION}

--- a/0.11/csharp/Dockerfile
+++ b/0.11/csharp/Dockerfile
@@ -38,7 +38,7 @@ RUN echo "deb http://download.mono-project.com/repo/debian wheezy main" | tee /e
 RUN echo "deb http://download.mono-project.com/repo/debian wheezy-apache24-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list
 RUN echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list
 RUN echo "deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main" | tee -a /etc/apt/sources.list.d/mono-xamarin.list
-RUN apt-get update && apt-get install -y mono-complete mono-devel nuget && apt-get clean
+RUN apt-get update && apt-get --no-install-recommends install -y mono-complete mono-devel nuget && apt-get clean
 
 # Install trusted root certificates needed to restore NuGet packages
 RUN mozroots --import --sync
@@ -47,7 +47,7 @@ ENV GRPC_RELEASE_TAG=0_11_0
 ENV GRPC_VERSION=0.11.0.0-1
 ENV GRPC_VERSION_BACKPORTS=${GRPC_VERSION}~bpo8+2
 
-RUN apt-get update && apt-get install -y -q wget libgrpc0=${GRPC_VERSION_BACKPORTS} && apt-get clean
+RUN apt-get update && apt-get --no-install-recommends install -y -q wget libgrpc0=${GRPC_VERSION_BACKPORTS} && apt-get clean
 
 # Download and install C# native extension
 RUN cd /root && wget https://github.com/grpc/grpc/releases/download/release-${GRPC_RELEASE_TAG}/libgrpc-csharp-ext0_${GRPC_VERSION}_amd64.deb \

--- a/0.11/cxx/Dockerfile
+++ b/0.11/cxx/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM buildpack-deps:jessie
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   autoconf \
   autotools-dev \
   build-essential \

--- a/0.11/node/Dockerfile
+++ b/0.11/node/Dockerfile
@@ -34,6 +34,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 ENV GRPC_VERSION 0.11.0.0-1~bpo8+2
 ENV GRPC_NODE_VERSION 0.11.0
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN npm install -g grpc@${GRPC_NODE_VERSION}

--- a/0.11/php/Dockerfile
+++ b/0.11/php/Dockerfile
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y -q apache2 git php5 php5-dev \
+RUN apt-get update && apt-get --no-install-recommends install -y -q apache2 git php5 php5-dev \
   phpunit php-pear
 
 RUN cd /usr/local/bin && curl -sS https://getcomposer.org/installer | php
@@ -37,7 +37,7 @@ RUN cd /usr/local/bin && mv composer.phar composer
 ENV GRPC_VERSION 0.11.1-1~bpo8+1
 RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | \
   tee -a /etc/apt/sources.list
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN pecl install grpc-beta
 RUN echo "extension=grpc.so" > /etc/php5/apache2/conf.d/30-grpc.ini

--- a/0.11/python/Dockerfile
+++ b/0.11/python/Dockerfile
@@ -34,6 +34,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 ENV GRPC_VERSION 0.11.0.0-1~bpo8+2
 ENV GRPC_PYTHON_VERSION 0.11.0b1
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN pip install grpcio==${GRPC_PYTHON_VERSION}

--- a/0.11/ruby/Dockerfile
+++ b/0.11/ruby/Dockerfile
@@ -34,6 +34,6 @@ RUN echo "deb http://ftp.us.debian.org/debian jessie-backports main" | tee -a /e
 ENV GRPC_VERSION 0.11.0.0-1~bpo8+2
 ENV GRPC_RUBY_VERSION 0.11.0
 
-RUN apt-get update && apt-get install -y -q libgrpc-dev=${GRPC_VERSION}
+RUN apt-get update && apt-get --no-install-recommends install -y -q libgrpc-dev=${GRPC_VERSION}
 
 RUN gem install grpc -v ${GRPC_RUBY_VERSION}

--- a/1.0/cxx/Dockerfile
+++ b/1.0/cxx/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   build-essential autoconf libtool \
   git \
   pkg-config \

--- a/1.0/php/Dockerfile
+++ b/1.0/php/Dockerfile
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 FROM php:7-apache
 
-RUN apt-get update && apt-get install -y -q git rake ruby-ronn zlib1g-dev && apt-get clean
+RUN apt-get update && apt-get --no-install-recommends install -y -q git rake ruby-ronn zlib1g-dev && apt-get clean
 
 # install composer
 RUN cd /usr/local/bin && curl -sS https://getcomposer.org/installer | php

--- a/1.10/cxx/Dockerfile
+++ b/1.10/cxx/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   build-essential autoconf git pkg-config \
   automake libtool curl make g++ unzip \
   && apt-get clean

--- a/1.12.0/cxx/Dockerfile
+++ b/1.12.0/cxx/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   build-essential autoconf libtool git pkg-config curl \
   automake libtool curl make g++ unzip \
   && apt-get clean

--- a/1.21.0/cxx/Dockerfile
+++ b/1.21.0/cxx/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   build-essential autoconf libtool git pkg-config curl \
   automake libtool curl make g++ unzip \
   && apt-get clean

--- a/1.8/cxx/Dockerfile
+++ b/1.8/cxx/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:stretch
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
   build-essential autoconf git pkg-config \
   automake libtool curl make g++ unzip \
   && apt-get clean


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

results in smaller image size.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>